### PR TITLE
fixed: 修复了一些兼容g2@4.x没有及时修改的错误

### DIFF
--- a/src/components/g2Components/area.vue
+++ b/src/components/g2Components/area.vue
@@ -86,7 +86,7 @@ export default {
     },
     // 内边距
     padding: {
-      type: Array || String,
+      type: [Array, String],
       default: function () {
         return 'auto'
       }

--- a/src/components/g2Components/bubble.vue
+++ b/src/components/g2Components/bubble.vue
@@ -93,7 +93,7 @@ export default {
     },
     // 内边距
     padding: {
-      type: Array || String,
+      type: [Array, String],
       default: function () {
         return 'auto'
       }

--- a/src/components/g2Components/column.vue
+++ b/src/components/g2Components/column.vue
@@ -87,7 +87,7 @@ export default {
     },
     // 内边距
     padding: {
-      type: Array || String,
+      type: [Array, String],
       default: function () {
         return 'auto'
       }

--- a/src/components/g2Components/custom.vue
+++ b/src/components/g2Components/custom.vue
@@ -16,7 +16,7 @@ export default {
   props: {
     // 内边距
     padding: {
-      type: Array || String,
+      type: [Array, String],
       default: function () {
         return 'auto'
       }

--- a/src/components/g2Components/double-axis-column.vue
+++ b/src/components/g2Components/double-axis-column.vue
@@ -78,7 +78,7 @@ export default {
     },
     // 内边距
     padding: {
-      type: Array || String,
+      type: [Array, String],
       default: function () {
         return 'auto'
       }

--- a/src/components/g2Components/histogram.vue
+++ b/src/components/g2Components/histogram.vue
@@ -48,7 +48,7 @@ export default {
     },
     // 内边距
     padding: {
-      type: Array || String,
+      type: [Array, String],
       default: function () {
         return 'auto'
       }

--- a/src/components/g2Components/line.vue
+++ b/src/components/g2Components/line.vue
@@ -86,7 +86,7 @@ export default {
     },
     // 内边距
     padding: {
-      type: Array || String,
+      type: [Array, String],
       default: function () {
         return 'auto'
       }

--- a/src/components/g2Components/liquidfill.vue
+++ b/src/components/g2Components/liquidfill.vue
@@ -49,7 +49,7 @@ export default {
     },
     // Canvas 内边距
     padding: {
-      type: Array || String,
+      type: [Array, String],
       default: function () {
         return 'auto'
       }

--- a/src/components/g2Components/mirror-interval.vue
+++ b/src/components/g2Components/mirror-interval.vue
@@ -53,7 +53,7 @@ export default {
     },
     // Canvas 内边距
     padding: {
-      type: Array || String,
+      type: [Array, String],
       default: function () {
         return 'auto'
       }

--- a/src/components/g2Components/pie.vue
+++ b/src/components/g2Components/pie.vue
@@ -81,7 +81,7 @@ export default {
     },
     // 内边距
     padding: {
-      type: Array || String,
+      type: [Array, String],
       default: function () {
         return 'auto'
       }

--- a/src/components/g2Components/radar.vue
+++ b/src/components/g2Components/radar.vue
@@ -85,7 +85,7 @@ export default {
     },
     // 内边距
     padding: {
-      type: Array || String,
+      type: [Array, String],
       default: function () {
         return 'auto'
       }

--- a/src/components/g2Components/scatter-point.vue
+++ b/src/components/g2Components/scatter-point.vue
@@ -101,7 +101,7 @@ export default {
     },
     // 内边距
     padding: {
-      type: Array || String,
+      type: [Array, String],
       default: function () {
         return 'auto'
       }

--- a/src/components/g2Components/word-cloud.vue
+++ b/src/components/g2Components/word-cloud.vue
@@ -10,6 +10,7 @@
 
 <script>
 import chartMix from '@/utils/chart.js'
+import { registerShape } from '@antv/g2'  // 修改了按需引入
 
 export default {
   name: 'g2-word-cloud',
@@ -48,21 +49,23 @@ export default {
       }
 
       function getTextAttrs (cfg) {
+        // cfg.origin 在4.中为cfg.mappingData
         return Object.assign({}, {
           fillOpacity: cfg.opacity,
-          fontSize: cfg.origin._origin.size,
-          rotate: cfg.origin._origin.rotate,
-          text: cfg.origin._origin.text,
+          fontSize: cfg.mappingData._origin.size,
+          rotate: cfg.mappingData._origin.rotate,
+          text: cfg.mappingData._origin.text,
           textAlign: 'center',
-          fontFamily: cfg.origin._origin.font,
+          fontFamily: cfg.mappingData._origin.font,
           fill: cfg.color,
           textBaseline: 'Alphabetic'
         }, cfg.style)
       }
-
       // 给point注册一个词云的shape
-      this.G2.Shape.registerShape('point', 'cloud', {
-        drawShape: function drawShape (cfg, container) {
+      // this.G2.Shape.registerShape错误，因为在chart.js中的引入修改了，这里没有及时修改（改为按需手动引入registerShape）
+      registerShape('point', 'cloud', {
+        // drawShape: function drawShape (cfg, container) {
+        draw: function draw (cfg, container) {
           var attrs = getTextAttrs(cfg)
           return container.addShape('text', {
             attrs: Object.assign(attrs, {


### PR DESCRIPTION
#### 由于工作使用了您当前的组件库，给我的开发带来了很多便利，十分感谢。但是在开发过程了也发现了该组件库中的一些小瑕疵，所以提出了下面几点修复解决方案：
1.修复了多处基础组件props的类型限制错误：`type: Array || String`应该修改成`type: [Array, String]`或`type: Array | String`;
2.修复word-cloud组件错误：
- 2.1.因为chart.js中，`import G2 from '@antv/g2'`修改成了`import { Chart } from '@antv/g2'`，所以组件内需要手动引入词云`import { registerShape } from '@antv/g2'`  
- 2.2.需要将`this.G2.Shape.registerShape`修改为`registerShape`，`drawShape`改为`draw`
- 2.1.`cfg.origin` 在g2@4.x中为`cfg.mappingData`
